### PR TITLE
Update main based on changes in upstream appsignal/rdkafka-ruby

### DIFF
--- a/lib/rdkafka.rb
+++ b/lib/rdkafka.rb
@@ -1,6 +1,13 @@
 require "rdkafka/version"
 
+require "rdkafka/abstract_handle"
+require "rdkafka/admin"
+require "rdkafka/admin/create_topic_handle"
+require "rdkafka/admin/create_topic_report"
+require "rdkafka/admin/delete_topic_handle"
+require "rdkafka/admin/delete_topic_report"
 require "rdkafka/bindings"
+require "rdkafka/callbacks"
 require "rdkafka/config"
 require "rdkafka/consumer"
 require "rdkafka/consumer/headers"

--- a/lib/rdkafka/abstract_handle.rb
+++ b/lib/rdkafka/abstract_handle.rb
@@ -1,0 +1,82 @@
+require "ffi"
+
+module Rdkafka
+  class AbstractHandle < FFI::Struct
+    # Subclasses must define their own layout, and the layout must start with:
+    #
+    # layout :pending, :bool,
+    #        :response, :int
+
+    REGISTRY = {}
+
+    CURRENT_TIME = -> { Process.clock_gettime(Process::CLOCK_MONOTONIC) }.freeze
+
+    private_constant :CURRENT_TIME
+
+    def self.register(handle)
+      address = handle.to_ptr.address
+      REGISTRY[address] = handle
+    end
+
+    def self.remove(address)
+      REGISTRY.delete(address)
+    end
+
+    # Whether the handle is still pending.
+    #
+    # @return [Boolean]
+    def pending?
+      self[:pending]
+    end
+
+    # Wait for the operation to complete or raise an error if this takes longer than the timeout.
+    # If there is a timeout this does not mean the operation failed, rdkafka might still be working on the operation.
+    # In this case it is possible to call wait again.
+    #
+    # @param max_wait_timeout [Numeric, nil] Amount of time to wait before timing out. If this is nil it does not time out.
+    # @param wait_timeout [Numeric] Amount of time we should wait before we recheck if the operation has completed
+    #
+    # @raise [RdkafkaError] When the operation failed
+    # @raise [WaitTimeoutError] When the timeout has been reached and the handle is still pending
+    #
+    # @return [Object] Operation-specific result
+    def wait(max_wait_timeout: 60, wait_timeout: 0.1)
+      timeout = if max_wait_timeout
+                  CURRENT_TIME.call + max_wait_timeout
+                else
+                  nil
+                end
+      loop do
+        if pending?
+          if timeout && timeout <= CURRENT_TIME.call
+            raise WaitTimeoutError.new("Waiting for #{operation_name} timed out after #{max_wait_timeout} seconds")
+          end
+          sleep wait_timeout
+        elsif self[:response] != 0
+          raise_error
+        else
+          return create_result
+        end
+      end
+    end
+
+    # @return [String] the name of the operation (e.g. "delivery")
+    def operation_name
+      raise "Must be implemented by subclass!"
+    end
+
+    # @return [Object] operation-specific result
+    def create_result
+      raise "Must be implemented by subclass!"
+    end
+
+    # Allow subclasses to override
+    def raise_error
+      raise RdkafkaError.new(self[:response])
+    end
+
+    # Error that is raised when waiting for the handle to complete
+    # takes longer than the specified timeout.
+    class WaitTimeoutError < RuntimeError; end
+  end
+end

--- a/lib/rdkafka/admin.rb
+++ b/lib/rdkafka/admin.rb
@@ -1,0 +1,144 @@
+module Rdkafka
+  class Admin
+    # @private
+    def initialize(native_kafka)
+      @native_kafka = native_kafka
+      @closing = false
+
+      # Start thread to poll client for callbacks
+      @polling_thread = Thread.new do
+        loop do
+          Rdkafka::Bindings.rd_kafka_poll(@native_kafka, 250)
+          # Exit thread if closing and the poll queue is empty
+          if @closing && Rdkafka::Bindings.rd_kafka_outq_len(@native_kafka) == 0
+            break
+          end
+        end
+      end
+      @polling_thread.abort_on_exception = true
+    end
+
+    # Close this admin instance
+    def close
+      return unless @native_kafka
+
+      # Indicate to polling thread that we're closing
+      @closing = true
+      # Wait for the polling thread to finish up
+      @polling_thread.join
+      Rdkafka::Bindings.rd_kafka_destroy(@native_kafka)
+      @native_kafka = nil
+    end
+
+    # Create a topic with the given partition count and replication factor
+    #
+    # @raise [ConfigError] When the partition count or replication factor are out of valid range
+    # @raise [RdkafkaError] When the topic name is invalid or the topic already exists
+    #
+    # @return [CreateTopicHandle] Create topic handle that can be used to wait for the result of creating the topic
+    def create_topic(topic_name, partition_count, replication_factor)
+
+      # Create a rd_kafka_NewTopic_t representing the new topic
+      error_buffer = FFI::MemoryPointer.from_string(" " * 256)
+      new_topic_ptr = Rdkafka::Bindings.rd_kafka_NewTopic_new(
+        FFI::MemoryPointer.from_string(topic_name),
+        partition_count,
+        replication_factor,
+        error_buffer,
+        256
+      )
+      if new_topic_ptr.null?
+        raise Rdkafka::Config::ConfigError.new(error_buffer.read_string)
+      end
+
+      # Note that rd_kafka_CreateTopics can create more than one topic at a time
+      pointer_array = [new_topic_ptr]
+      topics_array_ptr = FFI::MemoryPointer.new(:pointer)
+      topics_array_ptr.write_array_of_pointer(pointer_array)
+
+      # Get a pointer to the queue that our request will be enqueued on
+      queue_ptr = Rdkafka::Bindings.rd_kafka_queue_get_background(@native_kafka)
+      if queue_ptr.null?
+        Rdkafka::Bindings.rd_kafka_NewTopic_destroy(new_topic_ptr)
+        raise Rdkafka::Config::ConfigError.new("rd_kafka_queue_get_background was NULL")
+      end
+
+      # Create and register the handle we will return to the caller
+      create_topic_handle = CreateTopicHandle.new
+      create_topic_handle[:pending] = true
+      create_topic_handle[:response] = -1
+      CreateTopicHandle.register(create_topic_handle)
+      admin_options_ptr = Rdkafka::Bindings.rd_kafka_AdminOptions_new(@native_kafka, Rdkafka::Bindings::RD_KAFKA_ADMIN_OP_CREATETOPICS)
+      Rdkafka::Bindings.rd_kafka_AdminOptions_set_opaque(admin_options_ptr, create_topic_handle.to_ptr)
+
+      begin
+        Rdkafka::Bindings.rd_kafka_CreateTopics(
+            @native_kafka,
+            topics_array_ptr,
+            1,
+            admin_options_ptr,
+            queue_ptr
+        )
+      rescue Exception => err
+        CreateTopicHandle.remove(create_topic_handle.to_ptr.address)
+        raise
+      ensure
+        Rdkafka::Bindings.rd_kafka_AdminOptions_destroy(admin_options_ptr)
+        Rdkafka::Bindings.rd_kafka_queue_destroy(queue_ptr)
+        Rdkafka::Bindings.rd_kafka_NewTopic_destroy(new_topic_ptr)
+      end
+
+      create_topic_handle
+    end
+
+    # Delete the named topic
+    #
+    # @raise [RdkafkaError] When the topic name is invalid or the topic does not exist
+    #
+    # @return [DeleteTopicHandle] Delete topic handle that can be used to wait for the result of deleting the topic
+    def delete_topic(topic_name)
+
+      # Create a rd_kafka_DeleteTopic_t representing the topic to be deleted
+      delete_topic_ptr = Rdkafka::Bindings.rd_kafka_DeleteTopic_new(FFI::MemoryPointer.from_string(topic_name))
+
+      # Note that rd_kafka_DeleteTopics can create more than one topic at a time
+      pointer_array = [delete_topic_ptr]
+      topics_array_ptr = FFI::MemoryPointer.new(:pointer)
+      topics_array_ptr.write_array_of_pointer(pointer_array)
+
+      # Get a pointer to the queue that our request will be enqueued on
+      queue_ptr = Rdkafka::Bindings.rd_kafka_queue_get_background(@native_kafka)
+      if queue_ptr.null?
+        Rdkafka::Bindings.rd_kafka_DeleteTopic_destroy(delete_topic_ptr)
+        raise Rdkafka::Config::ConfigError.new("rd_kafka_queue_get_background was NULL")
+      end
+
+      # Create and register the handle we will return to the caller
+      delete_topic_handle = DeleteTopicHandle.new
+      delete_topic_handle[:pending] = true
+      delete_topic_handle[:response] = -1
+      DeleteTopicHandle.register(delete_topic_handle)
+      admin_options_ptr = Rdkafka::Bindings.rd_kafka_AdminOptions_new(@native_kafka, Rdkafka::Bindings::RD_KAFKA_ADMIN_OP_DELETETOPICS)
+      Rdkafka::Bindings.rd_kafka_AdminOptions_set_opaque(admin_options_ptr, delete_topic_handle.to_ptr)
+
+      begin
+        Rdkafka::Bindings.rd_kafka_DeleteTopics(
+            @native_kafka,
+            topics_array_ptr,
+            1,
+            admin_options_ptr,
+            queue_ptr
+        )
+      rescue Exception => err
+        DeleteTopicHandle.remove(delete_topic_handle.to_ptr.address)
+        raise
+      ensure
+        Rdkafka::Bindings.rd_kafka_AdminOptions_destroy(admin_options_ptr)
+        Rdkafka::Bindings.rd_kafka_queue_destroy(queue_ptr)
+        Rdkafka::Bindings.rd_kafka_DeleteTopic_destroy(delete_topic_ptr)
+      end
+
+      delete_topic_handle
+    end
+  end
+end

--- a/lib/rdkafka/admin/create_topic_handle.rb
+++ b/lib/rdkafka/admin/create_topic_handle.rb
@@ -1,0 +1,27 @@
+module Rdkafka
+  class Admin
+    class CreateTopicHandle < AbstractHandle
+      layout :pending, :bool,
+             :response, :int,
+             :error_string, :pointer,
+             :result_name, :pointer
+
+      # @return [String] the name of the operation
+      def operation_name
+        "create topic"
+      end
+
+      # @return [Boolean] whether the create topic was successful
+      def create_result
+        CreateTopicReport.new(self[:error_string], self[:result_name])
+      end
+
+      def raise_error
+        raise RdkafkaError.new(
+            self[:response],
+            broker_message: CreateTopicReport.new(self[:error_string], self[:result_name]).error_string
+        )
+      end
+    end
+  end
+end

--- a/lib/rdkafka/admin/create_topic_report.rb
+++ b/lib/rdkafka/admin/create_topic_report.rb
@@ -1,0 +1,22 @@
+module Rdkafka
+  class Admin
+    class CreateTopicReport
+      # Any error message generated from the CreateTopic
+      # @return [String]
+      attr_reader :error_string
+
+      # The name of the topic created
+      # @return [String]
+      attr_reader :result_name
+
+      def initialize(error_string, result_name)
+        if error_string != FFI::Pointer::NULL
+          @error_string = error_string.read_string
+        end
+        if result_name != FFI::Pointer::NULL
+          @result_name = @result_name = result_name.read_string
+        end
+      end
+    end
+  end
+end

--- a/lib/rdkafka/admin/delete_topic_handle.rb
+++ b/lib/rdkafka/admin/delete_topic_handle.rb
@@ -1,0 +1,27 @@
+module Rdkafka
+  class Admin
+    class DeleteTopicHandle < AbstractHandle
+      layout :pending, :bool,
+             :response, :int,
+             :error_string, :pointer,
+             :result_name, :pointer
+
+      # @return [String] the name of the operation
+      def operation_name
+        "delete topic"
+      end
+
+      # @return [Boolean] whether the delete topic was successful
+      def create_result
+        DeleteTopicReport.new(self[:error_string], self[:result_name])
+      end
+
+      def raise_error
+        raise RdkafkaError.new(
+            self[:response],
+            broker_message: DeleteTopicReport.new(self[:error_string], self[:result_name]).error_string
+        )
+      end
+    end
+  end
+end

--- a/lib/rdkafka/admin/delete_topic_report.rb
+++ b/lib/rdkafka/admin/delete_topic_report.rb
@@ -1,0 +1,22 @@
+module Rdkafka
+  class Admin
+    class DeleteTopicReport
+      # Any error message generated from the DeleteTopic
+      # @return [String]
+      attr_reader :error_string
+
+      # The name of the topic deleted
+      # @return [String]
+      attr_reader :result_name
+
+      def initialize(error_string, result_name)
+        if error_string != FFI::Pointer::NULL
+          @error_string = error_string.read_string
+        end
+        if result_name != FFI::Pointer::NULL
+          @result_name = @result_name = result_name.read_string
+        end
+      end
+    end
+  end
+end

--- a/lib/rdkafka/bindings.rb
+++ b/lib/rdkafka/bindings.rb
@@ -245,22 +245,49 @@ module Rdkafka
       rd_kafka_msg_partitioner_consistent_random(nil, str_ptr, str.size, partition_count, nil, nil)
     end
 
-    DeliveryCallback = FFI::Function.new(
-      :void, [:pointer, :pointer, :pointer]
-    ) do |client_ptr, message_ptr, opaque_ptr|
-      message = Message.new(message_ptr)
-      delivery_handle_ptr_address = message[:_private].address
-      if delivery_handle = Rdkafka::Producer::DeliveryHandle.remove(delivery_handle_ptr_address)
-        # Update delivery handle
-        delivery_handle[:pending] = false
-        delivery_handle[:response] = message[:err]
-        delivery_handle[:partition] = message[:partition]
-        delivery_handle[:offset] = message[:offset]
-        # Call delivery callback on opaque
-        if opaque = Rdkafka::Config.opaques[opaque_ptr.to_i]
-          opaque.call_delivery_callback(Rdkafka::Producer::DeliveryReport.new(message[:partition], message[:offset], message[:err]))
-        end
-      end
-    end
+    # Create Topics
+
+    RD_KAFKA_ADMIN_OP_CREATETOPICS     = 1   # rd_kafka_admin_op_t
+    RD_KAFKA_EVENT_CREATETOPICS_RESULT = 100 # rd_kafka_event_type_t
+
+    attach_function :rd_kafka_CreateTopics, [:pointer, :pointer, :size_t, :pointer, :pointer], :void
+    attach_function :rd_kafka_NewTopic_new, [:pointer, :size_t, :size_t, :pointer, :size_t], :pointer
+    attach_function :rd_kafka_NewTopic_destroy, [:pointer], :void
+    attach_function :rd_kafka_event_CreateTopics_result, [:pointer], :pointer
+    attach_function :rd_kafka_CreateTopics_result_topics, [:pointer, :pointer], :pointer
+
+    # Delete Topics
+
+    RD_KAFKA_ADMIN_OP_DELETETOPICS     = 2   # rd_kafka_admin_op_t
+    RD_KAFKA_EVENT_DELETETOPICS_RESULT = 101 # rd_kafka_event_type_t
+
+    attach_function :rd_kafka_DeleteTopics, [:pointer, :pointer, :size_t, :pointer, :pointer], :int32
+    attach_function :rd_kafka_DeleteTopic_new, [:pointer], :pointer
+    attach_function :rd_kafka_DeleteTopic_destroy, [:pointer], :void
+    attach_function :rd_kafka_event_DeleteTopics_result, [:pointer], :pointer
+    attach_function :rd_kafka_DeleteTopics_result_topics, [:pointer, :pointer], :pointer
+
+    # Background Queue and Callback
+
+    attach_function :rd_kafka_queue_get_background, [:pointer], :pointer
+    attach_function :rd_kafka_conf_set_background_event_cb, [:pointer, :pointer], :void
+    attach_function :rd_kafka_queue_destroy, [:pointer], :void
+
+    # Admin Options
+
+    attach_function :rd_kafka_AdminOptions_new, [:pointer, :int32], :pointer
+    attach_function :rd_kafka_AdminOptions_set_opaque, [:pointer, :pointer], :void
+    attach_function :rd_kafka_AdminOptions_destroy, [:pointer], :void
+
+    # Extracting data from event types
+
+    attach_function :rd_kafka_event_type, [:pointer], :int32
+    attach_function :rd_kafka_event_opaque, [:pointer], :pointer
+
+    # Extracting data from topic results
+
+    attach_function :rd_kafka_topic_result_error, [:pointer], :int32
+    attach_function :rd_kafka_topic_result_error_string, [:pointer], :pointer
+    attach_function :rd_kafka_topic_result_name, [:pointer], :pointer
   end
 end

--- a/lib/rdkafka/callbacks.rb
+++ b/lib/rdkafka/callbacks.rb
@@ -1,0 +1,106 @@
+module Rdkafka
+  module Callbacks
+
+    # Extracts attributes of a rd_kafka_topic_result_t
+    #
+    # @private
+    class TopicResult
+      attr_reader :result_error, :error_string, :result_name
+
+      def initialize(topic_result_pointer)
+        @result_error = Rdkafka::Bindings.rd_kafka_topic_result_error(topic_result_pointer)
+        @error_string = Rdkafka::Bindings.rd_kafka_topic_result_error_string(topic_result_pointer)
+        @result_name = Rdkafka::Bindings.rd_kafka_topic_result_name(topic_result_pointer)
+      end
+
+      def self.create_topic_results_from_array(count, array_pointer)
+        (1..count).map do |index|
+          result_pointer = (array_pointer + (index - 1)).read_pointer
+          new(result_pointer)
+        end
+      end
+    end
+
+    # FFI Function used for Create Topic and Delete Topic callbacks
+    BackgroundEventCallbackFunction = FFI::Function.new(
+        :void, [:pointer, :pointer, :pointer]
+    ) do |client_ptr, event_ptr, opaque_ptr|
+      BackgroundEventCallback.call(client_ptr, event_ptr, opaque_ptr)
+    end
+
+    # @private
+    class BackgroundEventCallback
+      def self.call(_, event_ptr, _)
+        event_type = Rdkafka::Bindings.rd_kafka_event_type(event_ptr)
+        if event_type == Rdkafka::Bindings::RD_KAFKA_EVENT_CREATETOPICS_RESULT
+          process_create_topic(event_ptr)
+        elsif event_type == Rdkafka::Bindings::RD_KAFKA_EVENT_DELETETOPICS_RESULT
+          process_delete_topic(event_ptr)
+        end
+      end
+
+      private
+
+      def self.process_create_topic(event_ptr)
+        create_topics_result = Rdkafka::Bindings.rd_kafka_event_CreateTopics_result(event_ptr)
+
+        # Get the number of create topic results
+        pointer_to_size_t = FFI::MemoryPointer.new(:int32)
+        create_topic_result_array = Rdkafka::Bindings.rd_kafka_CreateTopics_result_topics(create_topics_result, pointer_to_size_t)
+        create_topic_results = TopicResult.create_topic_results_from_array(pointer_to_size_t.read_int, create_topic_result_array)
+        create_topic_handle_ptr = Rdkafka::Bindings.rd_kafka_event_opaque(event_ptr)
+
+        if create_topic_handle = Rdkafka::Admin::CreateTopicHandle.remove(create_topic_handle_ptr.address)
+          create_topic_handle[:response] = create_topic_results[0].result_error
+          create_topic_handle[:error_string] = create_topic_results[0].error_string
+          create_topic_handle[:result_name] = create_topic_results[0].result_name
+          create_topic_handle[:pending] = false
+        end
+      end
+
+      def self.process_delete_topic(event_ptr)
+        delete_topics_result = Rdkafka::Bindings.rd_kafka_event_DeleteTopics_result(event_ptr)
+
+        # Get the number of topic results
+        pointer_to_size_t = FFI::MemoryPointer.new(:int32)
+        delete_topic_result_array = Rdkafka::Bindings.rd_kafka_DeleteTopics_result_topics(delete_topics_result, pointer_to_size_t)
+        delete_topic_results = TopicResult.create_topic_results_from_array(pointer_to_size_t.read_int, delete_topic_result_array)
+        delete_topic_handle_ptr = Rdkafka::Bindings.rd_kafka_event_opaque(event_ptr)
+
+        if delete_topic_handle = Rdkafka::Admin::DeleteTopicHandle.remove(delete_topic_handle_ptr.address)
+          delete_topic_handle[:response] = delete_topic_results[0].result_error
+          delete_topic_handle[:error_string] = delete_topic_results[0].error_string
+          delete_topic_handle[:result_name] = delete_topic_results[0].result_name
+          delete_topic_handle[:pending] = false
+        end
+      end
+    end
+
+    # FFI Function used for Message Delivery callbacks
+
+    DeliveryCallbackFunction = FFI::Function.new(
+        :void, [:pointer, :pointer, :pointer]
+    ) do |client_ptr, message_ptr, opaque_ptr|
+      DeliveryCallback.call(client_ptr, message_ptr, opaque_ptr)
+    end
+
+    # @private
+    class DeliveryCallback
+      def self.call(_, message_ptr, opaque_ptr)
+        message = Rdkafka::Bindings::Message.new(message_ptr)
+        delivery_handle_ptr_address = message[:_private].address
+        if delivery_handle = Rdkafka::Producer::DeliveryHandle.remove(delivery_handle_ptr_address)
+          # Update delivery handle
+          delivery_handle[:response] = message[:err]
+          delivery_handle[:partition] = message[:partition]
+          delivery_handle[:offset] = message[:offset]
+          delivery_handle[:pending] = false
+          # Call delivery callback on opaque
+          if opaque = Rdkafka::Config.opaques[opaque_ptr.to_i]
+            opaque.call_delivery_callback(Rdkafka::Producer::DeliveryReport.new(message[:partition], message[:offset], message[:err]))
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rdkafka/config.rb
+++ b/lib/rdkafka/config.rb
@@ -137,11 +137,24 @@ module Rdkafka
       # Create Kafka config
       config = native_config(opaque)
       # Set callback to receive delivery reports on config
-      Rdkafka::Bindings.rd_kafka_conf_set_dr_msg_cb(config, Rdkafka::Bindings::DeliveryCallback)
+      Rdkafka::Bindings.rd_kafka_conf_set_dr_msg_cb(config, Rdkafka::Callbacks::DeliveryCallbackFunction)
       # Return producer with Kafka client
       Rdkafka::Producer.new(native_kafka(config, :rd_kafka_producer)).tap do |producer|
         opaque.producer = producer
       end
+    end
+
+    # Create an admin instance with this configuration.
+    #
+    # @raise [ConfigError] When the configuration contains invalid options
+    # @raise [ClientCreationError] When the native client cannot be created
+    #
+    # @return [Admin] The created admin instance
+    def admin
+      opaque = Opaque.new
+      config = native_config(opaque)
+      Rdkafka::Bindings.rd_kafka_conf_set_background_event_cb(config, Rdkafka::Callbacks::BackgroundEventCallbackFunction)
+      Rdkafka::Admin.new(native_kafka(config, :rd_kafka_producer))
     end
 
     # Error that is returned by the underlying rdkafka error if an invalid configuration option is present.

--- a/lib/rdkafka/error.rb
+++ b/lib/rdkafka/error.rb
@@ -3,13 +3,22 @@ module Rdkafka
   class RdkafkaError < RuntimeError
     # The underlying raw error response
     # @return [Integer]
-    attr_reader :rdkafka_response, :message_prefix
+    attr_reader :rdkafka_response
+
+    # Prefix to be used for human readable representation
+    # @return [String]
+    attr_reader :message_prefix
+
+    # Error message sent by the broker
+    # @return [String]
+    attr_reader :broker_message
 
     # @private
-    def initialize(response, message_prefix=nil)
+    def initialize(response, message_prefix=nil, broker_message: nil)
       raise TypeError.new("Response has to be an integer") unless response.is_a? Integer
       @rdkafka_response = response
       @message_prefix = message_prefix
+      @broker_message = broker_message
     end
 
     # This error's code, for example `:partition_eof`, `:msg_size_too_large`.

--- a/lib/rdkafka/producer/delivery_handle.rb
+++ b/lib/rdkafka/producer/delivery_handle.rb
@@ -2,67 +2,21 @@ module Rdkafka
   class Producer
     # Handle to wait for a delivery report which is returned when
     # producing a message.
-    class DeliveryHandle < FFI::Struct
+    class DeliveryHandle < Rdkafka::AbstractHandle
       layout :pending, :bool,
              :response, :int,
              :partition, :int,
              :offset, :int64
 
-      REGISTRY = {}
-
-      CURRENT_TIME = -> { Process.clock_gettime(Process::CLOCK_MONOTONIC) }.freeze
-
-      private_constant :CURRENT_TIME
-
-      def self.register(address, handle)
-        REGISTRY[address] = handle
+      # @return [String] the name of the operation (e.g. "delivery")
+      def operation_name
+        "delivery"
       end
 
-      def self.remove(address)
-        REGISTRY.delete(address)
+      # @return [DeliveryReport] a report on the delivery of the message
+      def create_result
+        DeliveryReport.new(self[:partition], self[:offset])
       end
-
-      # Whether the delivery handle is still pending.
-      #
-      # @return [Boolean]
-      def pending?
-        self[:pending]
-      end
-
-      # Wait for the delivery report or raise an error if this takes longer than the timeout.
-      # If there is a timeout this does not mean the message is not delivered, rdkafka might still be working on delivering the message.
-      # In this case it is possible to call wait again.
-      #
-      # @param max_wait_timeout [Numeric, nil] Amount of time to wait before timing out. If this is nil it does not time out.
-      # @param wait_timeout [Numeric] Amount of time we should wait before we recheck if there is a delivery report available
-      #
-      # @raise [RdkafkaError] When delivering the message failed
-      # @raise [WaitTimeoutError] When the timeout has been reached and the handle is still pending
-      #
-      # @return [DeliveryReport]
-      def wait(max_wait_timeout: 60, wait_timeout: 0.1)
-        timeout = if max_wait_timeout
-                    CURRENT_TIME.call + max_wait_timeout
-                  else
-                    nil
-                  end
-        loop do
-          if pending?
-            if timeout && timeout <= CURRENT_TIME.call
-              raise WaitTimeoutError.new("Waiting for delivery timed out after #{max_wait_timeout} seconds")
-            end
-            sleep wait_timeout
-          elsif self[:response] != 0
-            raise RdkafkaError.new(self[:response])
-          else
-            return DeliveryReport.new(self[:partition], self[:offset])
-          end
-        end
-      end
-
-      # Error that is raised when waiting for a delivery handle to complete
-      # takes longer than the specified timeout.
-      class WaitTimeoutError < RuntimeError; end
     end
   end
 end

--- a/spec/rdkafka/abstract_handle_spec.rb
+++ b/spec/rdkafka/abstract_handle_spec.rb
@@ -1,0 +1,114 @@
+require "spec_helper"
+
+describe Rdkafka::AbstractHandle do
+  let(:response) { 0 }
+  let(:result) { -1 }
+
+  context "A subclass that does not implement the required methods" do
+
+    class BadTestHandle < Rdkafka::AbstractHandle
+      layout :pending, :bool,
+             :response, :int
+    end
+
+    it "raises an exception if operation_name is called" do
+      expect {
+        BadTestHandle.new.operation_name
+      }.to raise_exception(RuntimeError, /Must be implemented by subclass!/)
+    end
+
+    it "raises an exception if create_result is called" do
+      expect {
+        BadTestHandle.new.create_result
+      }.to raise_exception(RuntimeError, /Must be implemented by subclass!/)
+    end
+  end
+
+  class TestHandle < Rdkafka::AbstractHandle
+    layout :pending, :bool,
+           :response, :int,
+           :result, :int
+
+    def operation_name
+      "test_operation"
+    end
+
+    def create_result
+      self[:result]
+    end
+  end
+
+  subject do
+    TestHandle.new.tap do |handle|
+      handle[:pending] = pending_handle
+      handle[:response] = response
+      handle[:result] = result
+    end
+  end
+
+  describe ".register and .remove" do
+    let(:pending_handle) { true }
+
+    it "should register and remove a delivery handle" do
+      Rdkafka::AbstractHandle.register(subject)
+      removed = Rdkafka::AbstractHandle.remove(subject.to_ptr.address)
+      expect(removed).to eq subject
+      expect(Rdkafka::AbstractHandle::REGISTRY).to be_empty
+    end
+  end
+
+  describe "#pending?" do
+    context "when true" do
+      let(:pending_handle) { true }
+
+      it "should be true" do
+        expect(subject.pending?).to be true
+      end
+    end
+
+    context "when not true" do
+      let(:pending_handle) { false }
+
+      it "should be false" do
+        expect(subject.pending?).to be false
+      end
+    end
+  end
+
+  describe "#wait" do
+    let(:pending_handle) { true }
+
+    it "should wait until the timeout and then raise an error" do
+      expect {
+        subject.wait(max_wait_timeout: 0.1)
+      }.to raise_error Rdkafka::AbstractHandle::WaitTimeoutError, /test_operation/
+    end
+
+    context "when not pending anymore and no error" do
+      let(:pending_handle) { false }
+      let(:result) { 1 }
+
+      it "should return a result" do
+        wait_result = subject.wait
+        expect(wait_result).to eq(result)
+      end
+
+      it "should wait without a timeout" do
+        wait_result = subject.wait(max_wait_timeout: nil)
+        expect(wait_result).to eq(result)
+      end
+    end
+
+    context "when not pending anymore and there was an error" do
+      let(:pending_handle) { false }
+      let(:response) { 20 }
+
+      it "should raise an rdkafka error" do
+        expect {
+          subject.wait
+        }.to raise_error Rdkafka::RdkafkaError
+      end
+    end
+  end
+end
+

--- a/spec/rdkafka/admin/create_topic_handle_spec.rb
+++ b/spec/rdkafka/admin/create_topic_handle_spec.rb
@@ -1,0 +1,52 @@
+require "spec_helper"
+
+describe Rdkafka::Admin::CreateTopicHandle do
+  let(:response) { 0 }
+
+  subject do
+    Rdkafka::Admin::CreateTopicHandle.new.tap do |handle|
+      handle[:pending] = pending_handle
+      handle[:response] = response
+      handle[:error_string] = FFI::Pointer::NULL
+      handle[:result_name] = FFI::MemoryPointer.from_string("my-test-topic")
+    end
+  end
+
+  describe "#wait" do
+    let(:pending_handle) { true }
+
+    it "should wait until the timeout and then raise an error" do
+      expect {
+        subject.wait(max_wait_timeout: 0.1)
+      }.to raise_error Rdkafka::Admin::CreateTopicHandle::WaitTimeoutError, /create topic/
+    end
+
+    context "when not pending anymore and no error" do
+      let(:pending_handle) { false }
+
+      it "should return a create topic report" do
+        report = subject.wait
+
+        expect(report.error_string).to eq(nil)
+        expect(report.result_name).to eq("my-test-topic")
+      end
+
+      it "should wait without a timeout" do
+        report = subject.wait(max_wait_timeout: nil)
+
+        expect(report.error_string).to eq(nil)
+        expect(report.result_name).to eq("my-test-topic")
+      end
+    end
+  end
+
+  describe "#raise_error" do
+    let(:pending_handle) { false }
+
+    it "should raise the appropriate error" do
+      expect {
+        subject.raise_error
+      }.to raise_exception(Rdkafka::RdkafkaError, /Success \(no_error\)/)
+    end
+  end
+end

--- a/spec/rdkafka/admin/create_topic_report_spec.rb
+++ b/spec/rdkafka/admin/create_topic_report_spec.rb
@@ -1,0 +1,16 @@
+require "spec_helper"
+
+describe Rdkafka::Admin::CreateTopicReport do
+  subject { Rdkafka::Admin::CreateTopicReport.new(
+      FFI::MemoryPointer.from_string("error string"),
+      FFI::MemoryPointer.from_string("result name")
+  )}
+
+  it "should get the error string" do
+    expect(subject.error_string).to eq("error string")
+  end
+
+  it "should get the result name" do
+    expect(subject.result_name).to eq("result name")
+  end
+end

--- a/spec/rdkafka/admin/delete_topic_handle_spec.rb
+++ b/spec/rdkafka/admin/delete_topic_handle_spec.rb
@@ -1,0 +1,52 @@
+require "spec_helper"
+
+describe Rdkafka::Admin::DeleteTopicHandle do
+  let(:response) { 0 }
+
+  subject do
+    Rdkafka::Admin::DeleteTopicHandle.new.tap do |handle|
+      handle[:pending] = pending_handle
+      handle[:response] = response
+      handle[:error_string] = FFI::Pointer::NULL
+      handle[:result_name] = FFI::MemoryPointer.from_string("my-test-topic")
+    end
+  end
+
+  describe "#wait" do
+    let(:pending_handle) { true }
+
+    it "should wait until the timeout and then raise an error" do
+      expect {
+        subject.wait(max_wait_timeout: 0.1)
+      }.to raise_error Rdkafka::Admin::DeleteTopicHandle::WaitTimeoutError, /delete topic/
+    end
+
+    context "when not pending anymore and no error" do
+      let(:pending_handle) { false }
+
+      it "should return a delete topic report" do
+        report = subject.wait
+
+        expect(report.error_string).to eq(nil)
+        expect(report.result_name).to eq("my-test-topic")
+      end
+
+      it "should wait without a timeout" do
+        report = subject.wait(max_wait_timeout: nil)
+
+        expect(report.error_string).to eq(nil)
+        expect(report.result_name).to eq("my-test-topic")
+      end
+    end
+  end
+
+  describe "#raise_error" do
+    let(:pending_handle) { false }
+
+    it "should raise the appropriate error" do
+      expect {
+        subject.raise_error
+      }.to raise_exception(Rdkafka::RdkafkaError, /Success \(no_error\)/)
+    end
+  end
+end

--- a/spec/rdkafka/admin/delete_topic_report_spec.rb
+++ b/spec/rdkafka/admin/delete_topic_report_spec.rb
@@ -1,0 +1,16 @@
+require "spec_helper"
+
+describe Rdkafka::Admin::DeleteTopicReport do
+  subject { Rdkafka::Admin::DeleteTopicReport.new(
+      FFI::MemoryPointer.from_string("error string"),
+      FFI::MemoryPointer.from_string("result name")
+  )}
+
+  it "should get the error string" do
+    expect(subject.error_string).to eq("error string")
+  end
+
+  it "should get the result name" do
+    expect(subject.result_name).to eq("result name")
+  end
+end

--- a/spec/rdkafka/admin_spec.rb
+++ b/spec/rdkafka/admin_spec.rb
@@ -1,0 +1,179 @@
+require "spec_helper"
+require "ostruct"
+
+describe Rdkafka::Admin do
+  let(:config)   { rdkafka_config }
+  let(:admin)    { config.admin }
+
+  after do
+    # Registry should always end up being empty
+    expect(Rdkafka::Admin::CreateTopicHandle::REGISTRY).to be_empty
+    admin.close
+  end
+
+  let(:topic_name)               { "test-topic-#{Random.new.rand(0..1_000_000)}" }
+  let(:topic_partition_count)    { 3 }
+  let(:topic_replication_factor) { 1 }
+
+  describe "#create_topic" do
+    describe "called with invalid input" do
+      describe "with an invalid topic name" do
+        # https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/internals/Topic.java#L29
+        # public static final String LEGAL_CHARS = "[a-zA-Z0-9._-]";
+        let(:topic_name) { "[!@#]" }
+
+        it "raises an exception" do
+          create_topic_handle = admin.create_topic(topic_name, topic_partition_count, topic_replication_factor)
+          expect {
+            create_topic_handle.wait(max_wait_timeout: 15.0)
+          }.to raise_exception { |ex|
+            expect(ex).to be_a(Rdkafka::RdkafkaError)
+            expect(ex.message).to match(/Broker: Invalid topic \(topic_exception\)/)
+            expect(ex.broker_message).to match(/Topic name.*is illegal, it contains a character other than ASCII alphanumerics/)
+          }
+        end
+      end
+
+      describe "with the name of a topic that already exists" do
+        let(:topic_name) { "empty_test_topic" } # created in spec_helper.rb
+
+        it "raises an exception" do
+          create_topic_handle = admin.create_topic(topic_name, topic_partition_count, topic_replication_factor)
+          expect {
+            create_topic_handle.wait(max_wait_timeout: 15.0)
+          }.to raise_exception { |ex|
+            expect(ex).to be_a(Rdkafka::RdkafkaError)
+            expect(ex.message).to match(/Broker: Topic already exists \(topic_already_exists\)/)
+            expect(ex.broker_message).to match(/Topic 'empty_test_topic' already exists/)
+          }
+        end
+      end
+
+      describe "with an invalid partition count" do
+        let(:topic_partition_count) { -1 }
+
+        it "raises an exception" do
+          expect {
+            admin.create_topic(topic_name, topic_partition_count, topic_replication_factor)
+          }.to raise_error Rdkafka::Config::ConfigError, /num_partitions out of expected range/
+        end
+      end
+
+      describe "with an invalid replication factor" do
+        let(:topic_replication_factor) { -2  }
+
+        it "raises an exception" do
+          expect {
+            admin.create_topic(topic_name, topic_partition_count, topic_replication_factor)
+          }.to raise_error Rdkafka::Config::ConfigError, /replication_factor out of expected range/
+        end
+      end
+    end
+
+    context "edge case" do
+      context "where we are unable to get the background queue" do
+        before do
+          allow(Rdkafka::Bindings).to receive(:rd_kafka_queue_get_background).and_return(FFI::Pointer::NULL)
+        end
+
+        it "raises an exception" do
+          expect {
+            admin.create_topic(topic_name, topic_partition_count, topic_replication_factor)
+          }.to raise_error Rdkafka::Config::ConfigError, /rd_kafka_queue_get_background was NULL/
+        end
+      end
+
+      context "where rd_kafka_CreateTopics raises an exception" do
+        before do
+          allow(Rdkafka::Bindings).to receive(:rd_kafka_CreateTopics).and_raise(RuntimeError.new("oops"))
+        end
+
+        it "raises an exception" do
+          expect {
+            admin.create_topic(topic_name, topic_partition_count, topic_replication_factor)
+          }.to raise_error RuntimeError, /oops/
+        end
+      end
+    end
+
+    it "creates a topic" do
+      create_topic_handle = admin.create_topic(topic_name, topic_partition_count, topic_replication_factor)
+      create_topic_report = create_topic_handle.wait(max_wait_timeout: 15.0)
+      expect(create_topic_report.error_string).to be_nil
+      expect(create_topic_report.result_name).to eq(topic_name)
+    end
+  end
+
+  describe "#delete_topic" do
+    describe "called with invalid input" do
+      # https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/internals/Topic.java#L29
+      # public static final String LEGAL_CHARS = "[a-zA-Z0-9._-]";
+      describe "with an invalid topic name" do
+        let(:topic_name) { "[!@#]" }
+
+        it "raises an exception" do
+          delete_topic_handle = admin.delete_topic(topic_name)
+          expect {
+            delete_topic_handle.wait(max_wait_timeout: 15.0)
+          }.to raise_exception { |ex|
+            expect(ex).to be_a(Rdkafka::RdkafkaError)
+            expect(ex.message).to match(/Broker: Unknown topic or partition \(unknown_topic_or_part\)/)
+            expect(ex.broker_message).to match(/Broker: Unknown topic or partition/)
+          }
+        end
+      end
+
+      describe "with the name of a topic that does not exist" do
+        it "raises an exception" do
+          delete_topic_handle = admin.delete_topic(topic_name)
+          expect {
+            delete_topic_handle.wait(max_wait_timeout: 15.0)
+          }.to raise_exception { |ex|
+            expect(ex).to be_a(Rdkafka::RdkafkaError)
+            expect(ex.message).to match(/Broker: Unknown topic or partition \(unknown_topic_or_part\)/)
+            expect(ex.broker_message).to match(/Broker: Unknown topic or partition/)
+          }
+        end
+      end
+    end
+
+    context "edge case" do
+      context "where we are unable to get the background queue" do
+        before do
+          allow(Rdkafka::Bindings).to receive(:rd_kafka_queue_get_background).and_return(FFI::Pointer::NULL)
+        end
+
+        it "raises an exception" do
+          expect {
+            admin.delete_topic(topic_name)
+          }.to raise_error Rdkafka::Config::ConfigError, /rd_kafka_queue_get_background was NULL/
+        end
+      end
+
+      context "where rd_kafka_DeleteTopics raises an exception" do
+        before do
+          allow(Rdkafka::Bindings).to receive(:rd_kafka_DeleteTopics).and_raise(RuntimeError.new("oops"))
+        end
+
+        it "raises an exception" do
+          expect {
+            admin.delete_topic(topic_name)
+          }.to raise_error RuntimeError, /oops/
+        end
+      end
+    end
+
+
+    it "deletes a topic that was newly created" do
+      create_topic_handle = admin.create_topic(topic_name, topic_partition_count, topic_replication_factor)
+      create_topic_report = create_topic_handle.wait(max_wait_timeout: 15.0)
+      expect(create_topic_report.error_string).to be_nil
+      expect(create_topic_report.result_name).to eq(topic_name)
+
+      delete_topic_handle = admin.delete_topic(topic_name)
+      delete_topic_report = delete_topic_handle.wait(max_wait_timeout: 15.0)
+      expect(delete_topic_report.error_string).to be_nil
+      expect(delete_topic_report.result_name).to eq(topic_name)
+    end
+  end
+end

--- a/spec/rdkafka/callbacks_spec.rb
+++ b/spec/rdkafka/callbacks_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+
+describe Rdkafka::Callbacks do
+
+  # The code in the call back functions is 100% covered by other specs.  Due to
+  # the large number of collaborators, and the fact that FFI does not play
+  # nicely with doubles, it was very difficult to construct tests that were
+  # not over-mocked.
+
+  # For debugging purposes, if you suspect that you are running into trouble in
+  # one of the callback functions, it may be helpful to surround the inner body
+  # of the method with something like:
+  #
+  #   begin
+  #     <method body>
+  #   rescue => ex; puts ex.inspect; puts ex.backtrace; end;
+  #
+  # This will output to STDOUT any exceptions that are being raised in the callback.
+
+end

--- a/spec/rdkafka/error_spec.rb
+++ b/spec/rdkafka/error_spec.rb
@@ -11,6 +11,10 @@ describe Rdkafka::RdkafkaError do
     expect(Rdkafka::RdkafkaError.new(10, "message prefix").message_prefix).to eq "message prefix"
   end
 
+  it "should create an error with a broker message" do
+    expect(Rdkafka::RdkafkaError.new(10, broker_message: "broker message").broker_message).to eq "broker message"
+  end
+
   describe "#code" do
     it "should handle an invalid response" do
       expect(Rdkafka::RdkafkaError.new(933975).code).to eq :err_933975?

--- a/spec/rdkafka/metadata_spec.rb
+++ b/spec/rdkafka/metadata_spec.rb
@@ -1,0 +1,78 @@
+require "spec_helper"
+require "securerandom"
+
+describe Rdkafka::Metadata do
+  let(:config)        { rdkafka_config }
+  let(:native_config) { config.send(:native_config) }
+  let(:native_kafka)  { config.send(:native_kafka, native_config, :rd_kafka_consumer) }
+
+  after do
+    Rdkafka::Bindings.rd_kafka_consumer_close(native_kafka)
+    Rdkafka::Bindings.rd_kafka_destroy(native_kafka)
+  end
+
+  context "passing in a topic name" do
+    context "that is non-existent topic" do
+      let(:topic_name) { SecureRandom.uuid.to_s }
+
+      it "raises an appropriate exception" do
+        expect {
+          described_class.new(native_kafka, topic_name)
+        }.to raise_exception(Rdkafka::RdkafkaError, "Broker: Leader not available (leader_not_available)")
+      end
+    end
+
+    context "that is one of our test topics" do
+      subject { described_class.new(native_kafka, topic_name) }
+      let(:topic_name) { "partitioner_test_topic" }
+
+      it "#brokers returns our single broker" do
+        expect(subject.brokers.length).to eq(1)
+        expect(subject.brokers[0][:broker_id]).to eq(1)
+        expect(subject.brokers[0][:broker_name]).to eq("localhost")
+        expect(subject.brokers[0][:broker_port]).to eq(9092)
+      end
+
+      it "#topics returns data on our test topic" do
+        expect(subject.topics.length).to eq(1)
+        expect(subject.topics[0][:partition_count]).to eq(25)
+        expect(subject.topics[0][:partitions].length).to eq(25)
+        expect(subject.topics[0][:topic_name]).to eq(topic_name)
+      end
+    end
+  end
+
+  context "not passing in a topic name" do
+    subject { described_class.new(native_kafka, topic_name) }
+    let(:topic_name) { nil }
+    let(:test_topics) {
+      %w(consume_test_topic empty_test_topic load_test_topic produce_test_topic rake_test_topic watermarks_test_topic partitioner_test_topic)
+    } # Test topics crated in spec_helper.rb
+
+    it "#brokers returns our single broker" do
+      expect(subject.brokers.length).to eq(1)
+      expect(subject.brokers[0][:broker_id]).to eq(1)
+      expect(subject.brokers[0][:broker_name]).to eq("localhost")
+      expect(subject.brokers[0][:broker_port]).to eq(9092)
+    end
+
+    it "#topics returns data about all of our test topics" do
+      result = subject.topics.map { |topic| topic[:topic_name] }
+      expect(result).to include(*test_topics)
+    end
+  end
+
+  context "when a non-zero error code is returned" do
+    let(:topic_name) { SecureRandom.uuid.to_s }
+
+    before do
+      allow(Rdkafka::Bindings).to receive(:rd_kafka_metadata).and_return(-165)
+    end
+
+    it "creating the instance raises an exception" do
+      expect {
+        described_class.new(native_kafka, topic_name)
+      }.to raise_error(Rdkafka::RdkafkaError, /Local: Required feature not supported by broker \(unsupported_feature\)/)
+    end
+  end
+end

--- a/spec/rdkafka/producer/delivery_handle_spec.rb
+++ b/spec/rdkafka/producer/delivery_handle_spec.rb
@@ -12,42 +12,13 @@ describe Rdkafka::Producer::DeliveryHandle do
     end
   end
 
-  describe ".register and .remove" do
-    let(:pending_handle) { true }
-
-    it "should register and remove a delivery handle" do
-      Rdkafka::Producer::DeliveryHandle.register(subject.to_ptr.address, subject)
-      removed = Rdkafka::Producer::DeliveryHandle.remove(subject.to_ptr.address)
-      expect(removed).to eq subject
-      expect(Rdkafka::Producer::DeliveryHandle::REGISTRY).to be_empty
-    end
-  end
-
-  describe "#pending?" do
-    context "when true" do
-      let(:pending_handle) { true }
-
-      it "should be true" do
-        expect(subject.pending?).to be true
-      end
-    end
-
-    context "when not true" do
-      let(:pending_handle) { false }
-
-      it "should be false" do
-        expect(subject.pending?).to be false
-      end
-    end
-  end
-
   describe "#wait" do
     let(:pending_handle) { true }
 
     it "should wait until the timeout and then raise an error" do
       expect {
         subject.wait(max_wait_timeout: 0.1)
-      }.to raise_error Rdkafka::Producer::DeliveryHandle::WaitTimeoutError
+      }.to raise_error Rdkafka::Producer::DeliveryHandle::WaitTimeoutError, /delivery/
     end
 
     context "when not pending anymore and no error" do
@@ -65,17 +36,6 @@ describe Rdkafka::Producer::DeliveryHandle do
 
         expect(report.partition).to eq(2)
         expect(report.offset).to eq(100)
-      end
-    end
-
-    context "when not pending anymore and there was an error" do
-      let(:pending_handle) { false }
-      let(:response) { 20 }
-
-      it "should raise an rdkafka error" do
-        expect {
-          subject.wait
-        }.to raise_error Rdkafka::RdkafkaError
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
-require "simplecov"
-SimpleCov.start do
-  add_filter "/spec/"
+unless ENV["CI"] == "true"
+  require "simplecov"
+  SimpleCov.start do
+    add_filter "/spec/"
+  end
 end
 
 require "pry"


### PR DESCRIPTION
## The Problem

Our `main` has fallen out of data with the official remote upstream.

## The Solution

Merge in all changes from the official main branch.

## Notes

This contains most of the content from #2, so that PR will be closed shortly.

Some tests are still failing due to this issue described in this note (https://github.com/stitchfix/rdkafka-ruby/pull/3#issuecomment-662793483):

> The tests for this build are failing because we cannot run "docker-compose exec" in CircleCI to create the test topics.

A follow-up PR will solve this problem.