### PR TITLE
Ignore test topics that already exist

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -87,7 +87,12 @@ RSpec.configure do |config|
         partitioner_test_topic: 25,
     }.each do |topic, partitions|
       create_topic_handle = admin.create_topic(topic.to_s, partitions, 1)
-      create_topic_handle.wait(max_wait_timeout: 15)
+      begin
+        create_topic_handle.wait(max_wait_timeout: 15)
+      rescue Rdkafka::RdkafkaError => ex
+        raise unless ex.message.match?(/topic_already_exists/)
+      end
     end
+    admin.close
   end
 end


### PR DESCRIPTION
## The Problem

Not everyone runs `docker-compose rm` between test runs, so the test topics may already exist on the brokers.

## The Solution

Ignore messages related to the brokers already existing.

## The Bonus

Be a good citizen and clean up the admin instance we initialized to create the topics.
